### PR TITLE
Date de création du dossier dans Prevarisc

### DIFF
--- a/src/Service/Prevarisc.php
+++ b/src/Service/Prevarisc.php
@@ -167,7 +167,9 @@ class Prevarisc
 
             // On place des dates importantes dans Prevarisc
             $query_builder->setValue('DATESDIS_DOSSIER', $query_builder->createPositionalParameter((new \Datetime())->format('Y-m-d H:i:s')));
-            $query_builder->setValue('DATEINSERT_DOSSIER', $query_builder->createPositionalParameter((new \Datetime($consultation['dtEmission']))->format('Y-m-d H:i:s')));
+
+            $date_insertion = $consultation['dtEmission'] ?? $consultation['dtConsultation'] ?? 'now';
+            $query_builder->setValue('DATEINSERT_DOSSIER', $query_builder->createPositionalParameter((new \Datetime($date_insertion))->format('Y-m-d H:i:s')));
 
             // On associe la consultation Plat'AU avec le dossier créé
             $query_builder->setValue('ID_PLATAU', $query_builder->createPositionalParameter($consultation['idConsultation']));

--- a/src/Service/Prevarisc.php
+++ b/src/Service/Prevarisc.php
@@ -166,8 +166,8 @@ class Prevarisc
             $query_builder->setValue('SERVICEINSTRUC_DOSSIER', $query_builder->createPositionalParameter(null !== $service_instructeur ? $service_instructeur['designationActeur'] : null));
 
             // On place des dates importantes dans Prevarisc
-            $query_builder->setValue('DATESDIS_DOSSIER', $query_builder->createPositionalParameter((new \DateTime())->format('Y-m-d H:i:s')));
-            $query_builder->setValue('DATEINSERT_DOSSIER', $query_builder->createPositionalParameter((new \DateTime())->format('Y-m-d H:i:s')));
+            $query_builder->setValue('DATESDIS_DOSSIER', $query_builder->createPositionalParameter((new \Datetime())->format('Y-m-d H:i:s')));
+            $query_builder->setValue('DATEINSERT_DOSSIER', $query_builder->createPositionalParameter((new \Datetime($consultation['dtEmission']))->format('Y-m-d H:i:s')));
 
             // On associe la consultation Plat'AU avec le dossier créé
             $query_builder->setValue('ID_PLATAU', $query_builder->createPositionalParameter($consultation['idConsultation']));


### PR DESCRIPTION
Suite à l'[issue sur l'affichage de la date de création des dossiers dans Prevarisc](https://github.com/SDIS62/prevarisc-passerelle-platau/issues/49), je propose cette modification pour que la date de création du dossier dans Prevarisc corresponde à la date d'émission de la consultation depuis Plat'AU vers le SDIS.

Cela permet d'avoir la bonne information si la commande d'import des consultations a été en erreur plusieurs jours par exemple.
Dans ce cas précis, la date à laquelle la commande d'import a correctement récupérée la consultation est disponible puisqu'elle est déjà renseignée dans la date de réception par le SDIS.

Cordialement,
Maxime Merrien